### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Clone this repo and run `swift build` to download the dependencies, then run `.build/debug/FluentApp`
 
-View [Fluent](https://github.com/tannernelson/fluent) for documentation.
+View [Fluent](https://github.com/qutheory/fluent) for documentation.
 
 Swift 2.2 or later is required.
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/tannernelson/fluent | https://github.com/qutheory/fluent |
