### PR TITLE
Remove need to create 'main.sqlite' database and 'users' table by hand

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "FluentApp",
     dependencies: [
-        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1, minor: 3),
+        .Package(url: "https://github.com/vapor/fluent.git", majorVersion: 1, minor: 4),
         .Package(url: "https://github.com/vapor/fluent-sqlite.git", majorVersion: 1, minor: 1),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Fluent Example
 
+0. Make sure to have `sqlite3` installed (see **Install SQLite** bellow)
 1. Read through the Example Table section below to setup the sample database
 2. Run `swift package update` to download dependencies
 3. Run `swift build` to build the example application
@@ -9,9 +10,9 @@ View [Fluent](https://github.com/vapor/fluent) for documentation.
 
 Swift 3.0 or later is required.
 
-## Example Table
+## Install SQLite
 
-1. Install the `sqlite3` package. It's recommended to use a package manager:
+Install the `sqlite3` package. It's recommended to use a package manager:
 
 On macOS use [brew](http://brew.sh):
 
@@ -25,20 +26,5 @@ On Ubuntu use `apt-get`
 sudo apt-get update
 sudo apt-get install sqlite3 libsqlite3-dev
 ```
-
-Using the `sqlite3` command, create a database in the location the example
-app will look for:
-
-```bash
-sqlite3 Database/main.sqlite
-```
-
-That will put you in a sql prompt. Copy and paste the following SQL query to set up the example table.
-
-```sql
-CREATE TABLE users(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, age INT NOT NULL);
-```
-
-Then type `exit;` and you can open up the application with the steps at the top of this README.
 
 Works on macOS and Ubuntu.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Fluent Example
 
-0. Make sure to have `sqlite3` installed (see **Install SQLite** bellow)
-1. Read through the Example Table section below to setup the sample database
+1. Make sure to have `sqlite3` installed (see **Install SQLite** bellow)
 2. Run `swift package update` to download dependencies
 3. Run `swift build` to build the example application
 4. Execute the program `.build/debug/FluentApp`

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -18,6 +18,28 @@ do {
     print("Could not initialize driver: \(error)")
 }
 
+// Database preparation code from <https://github.com/vapor/fluent-provider/blob/master/Sources/Prepare.swift#L49-L62>
+
+let preparations: [Preparation.Type] = [User.self]
+if let database = Database.default {
+  do {
+      try preparations.forEach { preparation in
+          let name = "\(preparation.self)"
+
+          let hasPrepared = try database.hasPrepared(preparation)
+          // only prepare the unprepared
+          guard !hasPrepared else { return }
+          print("Preparing \(name)")
+          try database.prepare(preparation)
+          print("Prepared \(name)")
+      }
+  } catch {
+      print("Could not modify user: \(error)")
+  }
+
+  print("Database prepared")
+}
+
 do {
     if var user = try User.find(1) {
         print(user.name)


### PR DESCRIPTION
Added code to 'main.swift' from 'fluent-provider/Sources/Prepare.swift/prepare' function to remove the need for the user to create the 'main.sqlite' database and 'users' table by hand.